### PR TITLE
feat: sign JSON Web Tokens with AWS KMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,36 @@ This action doesn't approve pull requests unless they don't meet the following c
   - Required Permissions: `issues:write` To create GitHub Issue labels
   - Installed Repositories: client and server repositories
 - Run the client action in client workflows: [Example](https://github.com/csm-actions/demo-client/blob/c46ce73ffdaa83af182d733a382d5dc051d3b994/.github/workflows/approve.yaml#L11-L20)
+
+## Private keys in AWS KMS
+
+A GitHub App private key in GitHub Secrets never expires, so anyone who obtains
+it can generate installation access tokens indefinitely. Importing the key into
+AWS KMS removes that path: the key can never be exported, and only the JSON Web
+Token signing is delegated to it.
+
+Set `aws_kms_key_id` instead of `app_private_key`. Passing it as a key ARN is
+enough, since an ARN carries its region; for an alias or a bare key id, set
+`aws_region` or leave it to the AWS SDK.
+
+Set `aws_role_to_assume` and this action assumes the IAM role itself with the
+GitHub OIDC token. The AWS credentials then stay inside the action and are never
+exported, so later steps of the job can't see them. Leaving it unset uses the
+standard AWS credential chain, so `aws-actions/configure-aws-credentials` works
+as well.
+
+```yaml
+permissions:
+  id-token: write # Required to assume the AWS IAM role via OIDC
+  contents: read
+
+steps:
+  - uses: csm-actions/approve-pr-action@v0
+    with:
+      client_id: ${{vars.APP_CLIENT_ID}}
+      aws_kms_key_id: ${{vars.KMS_KEY_ID}}
+      aws_role_to_assume: ${{vars.ROLE_TO_ASSUME}}
+```
+
+The app can be identified by either `client_id` or `app_id`. `client_id` takes
+precedence when both are set.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ permissions:
   contents: read
 
 steps:
-  - uses: csm-actions/approve-pr-action@v0
+  - uses: csm-actions/approve-pr-action@452271472f121d6d2f8e7a0761488d2fcc29b715 # v0.2.0
     with:
       client_id: ${{vars.APP_CLIENT_ID}}
       aws_kms_key_id: ${{vars.KMS_KEY_ID}}

--- a/action.yaml
+++ b/action.yaml
@@ -7,12 +7,43 @@ branding:
 inputs:
   app_id:
     description: |
-      GitHub App ID
-    required: true
+      GitHub App ID.
+      Either client_id or app_id is required.
+    required: false
+  client_id:
+    description: |
+      GitHub App Client ID.
+      Either client_id or app_id is required.
+      client_id takes precedence when both are set.
+    required: false
   app_private_key:
     description: |
-      GitHub App Private Key
-    required: true
+      GitHub App Private Key.
+      Either app_private_key or aws_kms_key_id is required.
+    required: false
+  aws_kms_key_id:
+    description: |
+      Key ID, key ARN, alias name, or alias ARN of an AWS KMS key holding the
+      GitHub App private key.
+      Set this instead of app_private_key when the private key is stored in AWS
+      KMS and can never be exported.
+    required: false
+  aws_region:
+    description: |
+      The AWS region of the KMS key.
+      It can be omitted when aws_kms_key_id is an ARN, which carries the region.
+      Otherwise it falls back to the AWS SDK's own resolution, such as the
+      AWS_REGION environment variable.
+    required: false
+  aws_role_to_assume:
+    description: |
+      ARN of the AWS IAM role to assume with the GitHub OIDC token.
+      The job needs the permission `id-token: write`.
+      The credentials are kept inside this action and are never exported, so
+      later steps of the job can't see them.
+      Leave this unset to use the standard AWS credential chain instead, which
+      is what aws-actions/configure-aws-credentials sets up.
+    required: false
 
   # For Client
   server_repository_name:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,13 @@
       "dependencies": {
         "@actions/core": "3.0.1",
         "@actions/github": "9.1.1",
-        "@csm-actions/label": "npm:@jsr/csm-actions__label@^0.0.8",
+        "@aws-sdk/client-kms": "^3.1130.0",
+        "@csm-actions/label": "npm:@jsr/csm-actions__label@^0.1.0",
+        "@octokit/auth-app": "^8.3.1",
         "@octokit/rest": "^22.0.0",
-        "@suzuki-shunsuke/github-app-token": "npm:@jsr/suzuki-shunsuke__github-app-token@^0.0.4"
+        "@suzuki-shunsuke/actions-aws-oidc": "npm:@jsr/suzuki-shunsuke__actions-aws-oidc@^0.1.0",
+        "@suzuki-shunsuke/github-app-jwt-aws-kms": "npm:@jsr/suzuki-shunsuke__github-app-jwt-aws-kms@^0.1.1",
+        "@suzuki-shunsuke/github-app-token": "npm:@jsr/suzuki-shunsuke__github-app-token@^0.2.1"
       },
       "devDependencies": {
         "@types/node": "24.13.3",
@@ -77,25 +81,300 @@
       "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "license": "MIT"
     },
+    "node_modules/@aws-sdk/client-kms": {
+      "version": "3.1130.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1130.0.tgz",
+      "integrity": "sha512-hRmzoskEF9a9M9antlDbQsEKKWfR9B0ypYeFACUYLQnqN4Jsx2JU8N5dJsSWbpgwslpwnWDWXkOatyV/IechXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/credential-provider-node": "^3.972.83",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.978.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.978.0.tgz",
+      "integrity": "sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.71.tgz",
+      "integrity": "sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.73.tgz",
+      "integrity": "sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.16.tgz",
+      "integrity": "sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/credential-provider-env": "^3.972.71",
+        "@aws-sdk/credential-provider-http": "^3.972.73",
+        "@aws-sdk/credential-provider-login": "^3.972.78",
+        "@aws-sdk/credential-provider-process": "^3.972.71",
+        "@aws-sdk/credential-provider-sso": "^3.973.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.78.tgz",
+      "integrity": "sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.83",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.83.tgz",
+      "integrity": "sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.71",
+        "@aws-sdk/credential-provider-http": "^3.972.73",
+        "@aws-sdk/credential-provider-ini": "^3.973.16",
+        "@aws-sdk/credential-provider-process": "^3.972.71",
+        "@aws-sdk/credential-provider-sso": "^3.973.15",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.71.tgz",
+      "integrity": "sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.15.tgz",
+      "integrity": "sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/token-providers": "3.1129.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.77.tgz",
+      "integrity": "sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.45.tgz",
+      "integrity": "sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1129.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1129.0.tgz",
+      "integrity": "sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.978.0",
+        "@aws-sdk/nested-clients": "^3.997.45",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@csm-actions/label": {
       "name": "@jsr/csm-actions__label",
-      "version": "0.0.8",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/csm-actions__label/0.0.8.tgz",
-      "integrity": "sha512-o2CHX8eq4QWN/n1EBQl75K6DCMFOhFezhumY5sZGaMGlghvhTEVs5Q4TLWZkbQ7120QB/zxGHTuaRzzZW5cfAA==",
+      "version": "0.1.0",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/csm-actions__label/0.1.0.tgz",
+      "integrity": "sha512-nITBjOZEmOqR8DFSeTUuuQHNKhPTiRcXxdte0X+jISEziu3y2II2d8ELoMoIS1U9ALi6+ul9URSEe8BJQhztTQ==",
       "dependencies": {
         "@actions/core": "^3.0.1",
         "@actions/github": "^9.1.1",
-        "@jsr/suzuki-shunsuke__github-app-token": "^0.0.4"
+        "@jsr/suzuki-shunsuke__github-app-token": "^0.2.0"
       }
     },
+    "node_modules/@jsr/std__encoding": {
+      "version": "1.0.11",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/std__encoding/1.0.11.tgz",
+      "integrity": "sha512-4SmW8WXf4x4FjkxVpxbir06QYwxw/h/2+RU5A66iKXbJC9WAYCICZkH01mcOGj8FgSitF/lSTlT585RZfo8Ukg=="
+    },
     "node_modules/@jsr/suzuki-shunsuke__github-app-token": {
-      "version": "0.0.4",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__github-app-token/0.0.4.tgz",
-      "integrity": "sha512-U3CEYsbQt1OPl0sfpl02J5MPnlgoVLYmlssYc8yfI7V3S042jyMHV3cAWLpn5OmsuiZXk2agOYer0Ex66dtK7w==",
+      "version": "0.2.1",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__github-app-token/0.2.1.tgz",
+      "integrity": "sha512-/ubscHBvfwOyjSgKAsCdNX2ExBGsrhQAbF45J+CmzduSFcEiu1nueSZ1qmo4Ik/hck5Jg20H4QRo2n/Pk7K9pg==",
       "dependencies": {
-        "@octokit/auth-app": "^8.2.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
-        "@octokit/rest": "^22.0.1"
+        "@octokit/openapi-types": "^29.0.1"
       }
     },
     "node_modules/@octokit/auth-app": {
@@ -373,15 +652,113 @@
         "@octokit/openapi-types": "^29.0.1"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@suzuki-shunsuke/actions-aws-oidc": {
+      "name": "@jsr/suzuki-shunsuke__actions-aws-oidc",
+      "version": "0.1.0",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__actions-aws-oidc/0.1.0.tgz",
+      "integrity": "sha512-twLYZb+wADC9JMskfbJgCZwvGy+WP4gRKWTxt5XpKM16/E8wJCsNUoPt8ObBjUCbUShiSIB2ZufByBuQ0tb1Fg==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-web-identity": "^3.972.77"
+      }
+    },
+    "node_modules/@suzuki-shunsuke/github-app-jwt-aws-kms": {
+      "name": "@jsr/suzuki-shunsuke__github-app-jwt-aws-kms",
+      "version": "0.1.1",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__github-app-jwt-aws-kms/0.1.1.tgz",
+      "integrity": "sha512-d2NvHgiei2kdLyK5jRXnn/NLAZ0augaeYTPE8VMVr+HjxdrEDbPb4Uw9X4dHdg+NaruudrOORl7pK44q1jGjpw==",
+      "dependencies": {
+        "@aws-sdk/client-kms": "^3.1127.0",
+        "@jsr/std__encoding": "^1.0.11"
+      }
+    },
     "node_modules/@suzuki-shunsuke/github-app-token": {
       "name": "@jsr/suzuki-shunsuke__github-app-token",
-      "version": "0.0.4",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__github-app-token/0.0.4.tgz",
-      "integrity": "sha512-U3CEYsbQt1OPl0sfpl02J5MPnlgoVLYmlssYc8yfI7V3S042jyMHV3cAWLpn5OmsuiZXk2agOYer0Ex66dtK7w==",
+      "version": "0.2.1",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__github-app-token/0.2.1.tgz",
+      "integrity": "sha512-/ubscHBvfwOyjSgKAsCdNX2ExBGsrhQAbF45J+CmzduSFcEiu1nueSZ1qmo4Ik/hck5Jg20H4QRo2n/Pk7K9pg==",
       "dependencies": {
-        "@octokit/auth-app": "^8.2.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
-        "@octokit/rest": "^22.0.1"
+        "@octokit/openapi-types": "^29.0.1"
       }
     },
     "node_modules/@types/node": {
@@ -410,6 +787,12 @@
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
+    },
     "node_modules/content-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-3.0.0.tgz",
@@ -437,6 +820,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -7,9 +7,13 @@
   "dependencies": {
     "@actions/core": "3.0.1",
     "@actions/github": "9.1.1",
-    "@csm-actions/label": "npm:@jsr/csm-actions__label@^0.0.8",
+    "@aws-sdk/client-kms": "^3.1130.0",
+    "@csm-actions/label": "npm:@jsr/csm-actions__label@^0.1.0",
+    "@octokit/auth-app": "^8.3.1",
     "@octokit/rest": "^22.0.0",
-    "@suzuki-shunsuke/github-app-token": "npm:@jsr/suzuki-shunsuke__github-app-token@^0.0.4"
+    "@suzuki-shunsuke/actions-aws-oidc": "npm:@jsr/suzuki-shunsuke__actions-aws-oidc@^0.1.0",
+    "@suzuki-shunsuke/github-app-jwt-aws-kms": "npm:@jsr/suzuki-shunsuke__github-app-jwt-aws-kms@^0.1.1",
+    "@suzuki-shunsuke/github-app-token": "npm:@jsr/suzuki-shunsuke__github-app-token@^0.2.1"
   },
   "devDependencies": {
     "@types/node": "24.13.3",

--- a/src/app_octokit.ts
+++ b/src/app_octokit.ts
@@ -1,0 +1,71 @@
+import * as core from "@actions/core";
+import { KMSClient } from "@aws-sdk/client-kms";
+import { createAppAuth } from "@octokit/auth-app";
+import { Octokit } from "@octokit/rest";
+import { credentials } from "@suzuki-shunsuke/actions-aws-oidc";
+import { createJwt } from "@suzuki-shunsuke/github-app-jwt-aws-kms";
+
+/**
+ * Builds a KMS client.
+ *
+ * When aws_role_to_assume is set, the IAM role is assumed here with the GitHub
+ * OIDC token, and the resulting credentials never leave this process. Later
+ * steps of the job can't see them, unlike credentials that
+ * aws-actions/configure-aws-credentials exports as environment variables or
+ * writes to ~/.aws/credentials.
+ *
+ * Undefined leaves the client to @suzuki-shunsuke/github-app-jwt-aws-kms, which
+ * builds one from the key ARN's region and the standard AWS credential chain,
+ * so aws-actions/configure-aws-credentials works as well.
+ */
+const newKMSClient = (): KMSClient | undefined => {
+  const roleArn = core.getInput("aws_role_to_assume");
+  if (!roleArn) {
+    return undefined;
+  }
+  core.info(`assuming an AWS IAM role with the GitHub OIDC token: ${roleArn}`);
+  return new KMSClient({
+    region: core.getInput("aws_region") || undefined,
+    credentials: credentials({ roleArn }),
+  });
+};
+
+/**
+ * Builds an Octokit client authenticated as the GitHub App.
+ *
+ * When aws_kms_key_id is set, the private key never leaves AWS KMS and only the
+ * JSON Web Token signing is delegated to it. Otherwise app_private_key is used.
+ *
+ * The app is identified by either client_id or app_id. @octokit/auth-app passes
+ * the value straight through as the JSON Web Token issuer, and GitHub accepts
+ * both, recommending the Client ID.
+ */
+export const newAppOctokit = (): Octokit => {
+  const appId = core.getInput("client_id") || core.getInput("app_id");
+  if (!appId) {
+    throw new Error("Either client_id or app_id is required");
+  }
+  const kmsKeyId = core.getInput("aws_kms_key_id");
+  if (kmsKeyId) {
+    core.info(`signing GitHub App JSON Web Tokens with AWS KMS: ${kmsKeyId}`);
+    return new Octokit({
+      authStrategy: createAppAuth,
+      auth: {
+        appId,
+        createJwt: createJwt({
+          keyId: kmsKeyId,
+          region: core.getInput("aws_region") || undefined,
+          client: newKMSClient(),
+        }),
+      },
+    });
+  }
+  const privateKey = core.getInput("app_private_key");
+  if (!privateKey) {
+    throw new Error("Either app_private_key or aws_kms_key_id is required");
+  }
+  return new Octokit({
+    authStrategy: createAppAuth,
+    auth: { appId, privateKey },
+  });
+};

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,10 +2,9 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 import * as label from "@csm-actions/label";
 import { validate } from "./validate";
+import { newAppOctokit } from "./app_octokit";
 
 export const action = async () => {
-  const appID = core.getInput("app_id", { required: true });
-  const appPrivateKey = core.getInput("app_private_key", { required: true });
   const serverRepositoryName = core.getInput("server_repository_name", {
     required: true,
   });
@@ -57,8 +56,7 @@ export const action = async () => {
   );
 
   await label.create({
-    appId: appID,
-    privateKey: appPrivateKey,
+    appOctokit: newAppOctokit(),
     owner: serverRepositoryOwner,
     repo: serverRepositoryName,
     name: labelName,

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 import * as githubAppToken from "@suzuki-shunsuke/github-app-token";
 import { validate } from "./validate";
+import { newAppOctokit } from "./app_octokit";
 
 const parseLabelDescription = (
   description: string,
@@ -41,8 +42,7 @@ export const action = async () => {
     })}`,
   );
   const token = await githubAppToken.create({
-    appId: core.getInput("app_id", { required: true }),
-    privateKey: core.getInput("app_private_key", { required: true }),
+    octokit: newAppOctokit(),
     owner: owner,
     repositories: [repo],
     permissions: permissions,


### PR DESCRIPTION
## Why

A GitHub App private key in GitHub Secrets never expires. Anyone who obtains it can generate installation access tokens for as long as the key stays registered on the app.

Importing the key into AWS KMS removes that path: the key can never be exported, and only the JSON Web Token signing is delegated to it.

This action creates the tokens itself rather than taking one from a separate token action, so the KMS support belongs here. It already knows which permissions and repositories it needs, and a workflow author shouldn't have to restate them on another step.

## What

- `aws_kms_key_id` signs the JSON Web Token with AWS KMS instead of `app_private_key`, which becomes optional. One of the two is required.
- `aws_role_to_assume` assumes the AWS IAM role here with the GitHub OIDC token, so the credentials stay in this process instead of being exported by `aws-actions/configure-aws-credentials` where the rest of the job can read them. Leaving it unset uses the standard AWS credential chain, so that action still works.
- `aws_region` covers a key id that isn't an ARN. An ARN already carries its region, so it's usually unnecessary.
- `client_id` joins `app_id`. GitHub accepts either as the JSON Web Token issuer, and `client_id` takes precedence when both are set.

`src/app_octokit.ts` builds the app authenticated client, shared by the client and the server side.

This also moves `@suzuki-shunsuke/github-app-token` to 0.2.1 and `@csm-actions/label` to 0.1.0. Both stopped authenticating as the app themselves and take a client instead, which is what removed the duplicate `@octokit/plugin-rest-endpoint-methods` that used to sit alongside the one `@actions/github` brings.

Existing workflows passing `app_id` and `app_private_key` need no change.

## Verification

`npm run build` and `actionlint` and `ghalint run` pass.

The KMS path was exercised from this action's own code against the real KMS key holding a real GitHub App's private key, and against real GitHub:

```
signing GitHub App JSON Web Tokens with AWS KMS: arn:aws:kms:ap-northeast-1:...
authenticated as: szksh-lab-2-no-permission
```

That run had no `AWS_REGION` set, which confirms the region comes from the key ARN. Passing neither `app_private_key` nor `aws_kms_key_id` reports `Either app_private_key or aws_kms_key_id is required`.

The `aws_role_to_assume` path only works on a runner, and the IAM role's trust policy would have to list this repository first, so it isn't proven end to end here.

`tsc` reports one pre-existing error in `node_modules/@octokit/request-error`, because `tsconfig.json` sets `lib: ["ES2021"]` and `ErrorOptions` arrived in ES2022. It is there on `main` too, and this repository has no `lint` script, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
