### PR TITLE
fix: resolve the KMS region from the key ARN

### DIFF
--- a/src/app_octokit.ts
+++ b/src/app_octokit.ts
@@ -3,7 +3,10 @@ import { KMSClient } from "@aws-sdk/client-kms";
 import { createAppAuth } from "@octokit/auth-app";
 import { Octokit } from "@octokit/rest";
 import { credentials } from "@suzuki-shunsuke/actions-aws-oidc";
-import { createJwt } from "@suzuki-shunsuke/github-app-jwt-aws-kms";
+import {
+  createJwt,
+  regionFromKeyId,
+} from "@suzuki-shunsuke/github-app-jwt-aws-kms";
 
 /**
  * Builds a KMS client.
@@ -17,15 +20,21 @@ import { createJwt } from "@suzuki-shunsuke/github-app-jwt-aws-kms";
  * Undefined leaves the client to @suzuki-shunsuke/github-app-jwt-aws-kms, which
  * builds one from the key ARN's region and the standard AWS credential chain,
  * so aws-actions/configure-aws-credentials works as well.
+ *
+ * The region is resolved here rather than left to that module, which only sees
+ * a client it was given and can't tell it a region afterwards. Without this the
+ * key ARN's region would be ignored and the AWS SDK would fail with "Region is
+ * missing" on a runner that sets none.
  */
-const newKMSClient = (): KMSClient | undefined => {
+const newKMSClient = (keyId: string): KMSClient | undefined => {
   const roleArn = core.getInput("aws_role_to_assume");
   if (!roleArn) {
     return undefined;
   }
   core.info(`assuming an AWS IAM role with the GitHub OIDC token: ${roleArn}`);
   return new KMSClient({
-    region: core.getInput("aws_region") || undefined,
+    // Undefined leaves the region to the AWS SDK's own resolution.
+    region: core.getInput("aws_region") || regionFromKeyId(keyId) || undefined,
     credentials: credentials({ roleArn }),
   });
 };
@@ -55,7 +64,7 @@ export const newAppOctokit = (): Octokit => {
         createJwt: createJwt({
           keyId: kmsKeyId,
           region: core.getInput("aws_region") || undefined,
-          client: newKMSClient(),
+          client: newKMSClient(kmsKeyId),
         }),
       },
     });


### PR DESCRIPTION
`aws_kms_key_id` documents that `aws_region` can be omitted when the key id is an ARN, since an ARN carries its region. It can't: such a run fails with `Region is missing`.

When `aws_role_to_assume` is set, `newKMSClient` builds the `KMSClient` itself and hands it to `createJwt`. `@suzuki-shunsuke/github-app-jwt-aws-kms` only derives a region from the key ARN on the path where it builds the client, and a client it was given can't be told a region afterwards. So the ARN's region was dropped and the AWS SDK found none in the runner's environment either.

Resolve it with the module's own `regionFromKeyId` where the client is built, so `aws_region` is only needed for what an ARN can't cover, such as an alias name or a bare key id.

csm-actions/securefix-action#793 and csm-actions/update-branch-action#514 fixed the same bug in the same way.

Found while migrating szksh-lab/securefix-demo-server to sign with KMS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)