### PR TITLE
feat: drop the AWS SDK from the bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,11 @@
       "dependencies": {
         "@actions/core": "3.0.1",
         "@actions/github": "9.1.1",
-        "@aws-sdk/client-kms": "^3.1130.0",
         "@csm-actions/label": "npm:@jsr/csm-actions__label@^0.1.0",
         "@octokit/auth-app": "^8.3.1",
         "@octokit/rest": "^22.0.0",
-        "@suzuki-shunsuke/actions-aws-oidc": "npm:@jsr/suzuki-shunsuke__actions-aws-oidc@^0.1.0",
-        "@suzuki-shunsuke/github-app-jwt-aws-kms": "npm:@jsr/suzuki-shunsuke__github-app-jwt-aws-kms@^0.1.1",
+        "@suzuki-shunsuke/actions-aws-oidc": "npm:@jsr/suzuki-shunsuke__actions-aws-oidc@^0.2.0",
+        "@suzuki-shunsuke/github-app-jwt-aws-kms": "npm:@jsr/suzuki-shunsuke__github-app-jwt-aws-kms@^0.2.0",
         "@suzuki-shunsuke/github-app-token": "npm:@jsr/suzuki-shunsuke__github-app-token@^0.2.1"
       },
       "devDependencies": {
@@ -80,278 +79,6 @@
       "resolved": "https://registry.npmjs.org/@actions/io/-/io-3.0.2.tgz",
       "integrity": "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw==",
       "license": "MIT"
-    },
-    "node_modules/@aws-sdk/client-kms": {
-      "version": "3.1130.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.1130.0.tgz",
-      "integrity": "sha512-hRmzoskEF9a9M9antlDbQsEKKWfR9B0ypYeFACUYLQnqN4Jsx2JU8N5dJsSWbpgwslpwnWDWXkOatyV/IechXg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/credential-provider-node": "^3.972.83",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/fetch-http-handler": "^5.7.2",
-        "@smithy/node-http-handler": "^4.11.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/core": {
-      "version": "3.978.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.978.0.tgz",
-      "integrity": "sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.974.5",
-        "@aws-sdk/xml-builder": "^3.972.40",
-        "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.33.3",
-        "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.17.2",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.71.tgz",
-      "integrity": "sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.73",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.73.tgz",
-      "integrity": "sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/fetch-http-handler": "^5.7.2",
-        "@smithy/node-http-handler": "^4.11.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.16.tgz",
-      "integrity": "sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/credential-provider-env": "^3.972.71",
-        "@aws-sdk/credential-provider-http": "^3.972.73",
-        "@aws-sdk/credential-provider-login": "^3.972.78",
-        "@aws-sdk/credential-provider-process": "^3.972.71",
-        "@aws-sdk/credential-provider-sso": "^3.973.15",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
-        "@aws-sdk/nested-clients": "^3.997.45",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.78",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.78.tgz",
-      "integrity": "sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/nested-clients": "^3.997.45",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.83",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.83.tgz",
-      "integrity": "sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.71",
-        "@aws-sdk/credential-provider-http": "^3.972.73",
-        "@aws-sdk/credential-provider-ini": "^3.973.16",
-        "@aws-sdk/credential-provider-process": "^3.972.71",
-        "@aws-sdk/credential-provider-sso": "^3.973.15",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.77",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.71",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.71.tgz",
-      "integrity": "sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.15.tgz",
-      "integrity": "sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/nested-clients": "^3.997.45",
-        "@aws-sdk/token-providers": "3.1129.0",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.77",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.77.tgz",
-      "integrity": "sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/nested-clients": "^3.997.45",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.45",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.45.tgz",
-      "integrity": "sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/fetch-http-handler": "^5.7.2",
-        "@smithy/node-http-handler": "^4.11.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
-      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1129.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1129.0.tgz",
-      "integrity": "sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.978.0",
-        "@aws-sdk/nested-clients": "^3.997.45",
-        "@aws-sdk/types": "^3.974.5",
-        "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types": {
-      "version": "3.974.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
-      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
-      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
-      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
     },
     "node_modules/@csm-actions/label": {
       "name": "@jsr/csm-actions__label",
@@ -652,104 +379,20 @@
         "@octokit/openapi-types": "^29.0.1"
       }
     },
-    "node_modules/@smithy/core": {
-      "version": "3.33.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
-      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
-      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.33.2",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
-      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.18.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/node-http-handler": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
-      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.18.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/signature-v4": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
-      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.33.3",
-        "@smithy/types": "^4.17.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/types": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
-      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@suzuki-shunsuke/actions-aws-oidc": {
       "name": "@jsr/suzuki-shunsuke__actions-aws-oidc",
-      "version": "0.1.0",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__actions-aws-oidc/0.1.0.tgz",
-      "integrity": "sha512-twLYZb+wADC9JMskfbJgCZwvGy+WP4gRKWTxt5XpKM16/E8wJCsNUoPt8ObBjUCbUShiSIB2ZufByBuQ0tb1Fg==",
-      "dependencies": {
-        "@aws-sdk/credential-provider-web-identity": "^3.972.77"
-      }
+      "version": "0.2.0",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__actions-aws-oidc/0.2.0.tgz",
+      "integrity": "sha512-PGR7DBSjqTYDLRzPrCQVBhbbRr8QxxeduXCZwc2I1Tkujq/ehQfPkW1c4feL/GNTrknt0+U5RX0/9ITLuGsNyw=="
     },
     "node_modules/@suzuki-shunsuke/github-app-jwt-aws-kms": {
       "name": "@jsr/suzuki-shunsuke__github-app-jwt-aws-kms",
-      "version": "0.1.1",
-      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__github-app-jwt-aws-kms/0.1.1.tgz",
-      "integrity": "sha512-d2NvHgiei2kdLyK5jRXnn/NLAZ0augaeYTPE8VMVr+HjxdrEDbPb4Uw9X4dHdg+NaruudrOORl7pK44q1jGjpw==",
+      "version": "0.2.0",
+      "resolved": "https://npm.jsr.io/~/11/@jsr/suzuki-shunsuke__github-app-jwt-aws-kms/0.2.0.tgz",
+      "integrity": "sha512-+UUzN5sFF+8dh6ozLeNWLK5GN6d33lF4j5GSEGr+KlzL6G/Ok4CowbC3ZH/KnVb4NsmVfaxxOYHN48WQRxOqoA==",
       "dependencies": {
-        "@aws-sdk/client-kms": "^3.1127.0",
-        "@jsr/std__encoding": "^1.0.11"
+        "@jsr/std__encoding": "^1.0.11",
+        "aws4fetch": "^1.0.20"
       }
     },
     "node_modules/@suzuki-shunsuke/github-app-token": {
@@ -781,17 +424,17 @@
         "ncc": "dist/ncc/cli.js"
       }
     },
+    "node_modules/aws4fetch": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/aws4fetch/-/aws4fetch-1.0.20.tgz",
+      "integrity": "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==",
+      "license": "MIT"
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
       "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
-    },
-    "node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
-      "license": "MIT"
     },
     "node_modules/content-type": {
       "version": "3.0.0",
@@ -820,12 +463,6 @@
       "engines": {
         "node": ">=20"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,11 @@
   "dependencies": {
     "@actions/core": "3.0.1",
     "@actions/github": "9.1.1",
-    "@aws-sdk/client-kms": "^3.1130.0",
     "@csm-actions/label": "npm:@jsr/csm-actions__label@^0.1.0",
     "@octokit/auth-app": "^8.3.1",
     "@octokit/rest": "^22.0.0",
-    "@suzuki-shunsuke/actions-aws-oidc": "npm:@jsr/suzuki-shunsuke__actions-aws-oidc@^0.1.0",
-    "@suzuki-shunsuke/github-app-jwt-aws-kms": "npm:@jsr/suzuki-shunsuke__github-app-jwt-aws-kms@^0.1.1",
+    "@suzuki-shunsuke/actions-aws-oidc": "npm:@jsr/suzuki-shunsuke__actions-aws-oidc@^0.2.0",
+    "@suzuki-shunsuke/github-app-jwt-aws-kms": "npm:@jsr/suzuki-shunsuke__github-app-jwt-aws-kms@^0.2.0",
     "@suzuki-shunsuke/github-app-token": "npm:@jsr/suzuki-shunsuke__github-app-token@^0.2.1"
   },
   "devDependencies": {

--- a/src/app_octokit.ts
+++ b/src/app_octokit.ts
@@ -1,42 +1,45 @@
 import * as core from "@actions/core";
-import { KMSClient } from "@aws-sdk/client-kms";
 import { createAppAuth } from "@octokit/auth-app";
 import { Octokit } from "@octokit/rest";
 import { credentials } from "@suzuki-shunsuke/actions-aws-oidc";
 import {
   createJwt,
+  type CredentialsProvider,
   regionFromKeyId,
 } from "@suzuki-shunsuke/github-app-jwt-aws-kms";
 
 /**
- * Builds a KMS client.
+ * Works out the AWS region of the KMS key.
  *
- * When aws_role_to_assume is set, the IAM role is assumed here with the GitHub
- * OIDC token, and the resulting credentials never leave this process. Later
- * steps of the job can't see them, unlike credentials that
+ * A key ARN carries its region, so aws_region is only needed for an alias name
+ * or a bare key id. The same region is used for the STS endpoint, so that a job
+ * doesn't have to name it twice.
+ */
+const awsRegion = (keyId: string): string | undefined =>
+  core.getInput("aws_region") || regionFromKeyId(keyId) || undefined;
+
+/**
+ * Builds the AWS credentials used to call the KMS Sign API.
+ *
+ * When aws_role_to_assume is set, the IAM role is assumed with the GitHub OIDC
+ * token, and the resulting credentials never leave this process. Later steps of
+ * the job can't see them, unlike credentials that
  * aws-actions/configure-aws-credentials exports as environment variables or
  * writes to ~/.aws/credentials.
  *
- * Undefined leaves the client to @suzuki-shunsuke/github-app-jwt-aws-kms, which
- * builds one from the key ARN's region and the standard AWS credential chain,
- * so aws-actions/configure-aws-credentials works as well.
- *
- * The region is resolved here rather than left to that module, which only sees
- * a client it was given and can't tell it a region afterwards. Without this the
- * key ARN's region would be ignored and the AWS SDK would fail with "Region is
- * missing" on a runner that sets none.
+ * Undefined leaves them to @suzuki-shunsuke/github-app-jwt-aws-kms, which reads
+ * AWS_ACCESS_KEY_ID and friends, so aws-actions/configure-aws-credentials works
+ * as well.
  */
-const newKMSClient = (keyId: string): KMSClient | undefined => {
+const newCredentials = (
+  region: string | undefined,
+): CredentialsProvider | undefined => {
   const roleArn = core.getInput("aws_role_to_assume");
   if (!roleArn) {
     return undefined;
   }
   core.info(`assuming an AWS IAM role with the GitHub OIDC token: ${roleArn}`);
-  return new KMSClient({
-    // Undefined leaves the region to the AWS SDK's own resolution.
-    region: core.getInput("aws_region") || regionFromKeyId(keyId) || undefined,
-    credentials: credentials({ roleArn }),
-  });
+  return credentials({ roleArn, region });
 };
 
 /**
@@ -57,14 +60,15 @@ export const newAppOctokit = (): Octokit => {
   const kmsKeyId = core.getInput("aws_kms_key_id");
   if (kmsKeyId) {
     core.info(`signing GitHub App JSON Web Tokens with AWS KMS: ${kmsKeyId}`);
+    const region = awsRegion(kmsKeyId);
     return new Octokit({
       authStrategy: createAppAuth,
       auth: {
         appId,
         createJwt: createJwt({
           keyId: kmsKeyId,
-          region: core.getInput("aws_region") || undefined,
-          client: newKMSClient(kmsKeyId),
+          region,
+          credentials: newCredentials(region),
         }),
       },
     });


### PR DESCRIPTION
The KMS support brought `@aws-sdk/client-kms` with it, and `@suzuki-shunsuke/actions-aws-oidc` brought `@aws-sdk/credential-provider-web-identity`. Together they cost 1.12 MiB of a 2.50 MiB bundle in order to make two API calls, and an action pays that on every job because GitHub Actions downloads it each time.

Both libraries now call those APIs over HTTPS directly, so the SDK is gone from `node_modules` entirely:

- [github-app-jwt-aws-kms 0.2.0](https://github.com/suzuki-shunsuke/github-app-jwt-aws-kms-ts/releases/tag/0.2.0) signs with SigV4 via `aws4fetch`
- [actions-aws-oidc 0.2.0](https://github.com/suzuki-shunsuke/actions-aws-oidc-ts/releases/tag/0.2.0) posts to `AssumeRoleWithWebIdentity`, which carries no signature because the OIDC token is what authenticates it

## Measurement

Both figures are a real `npm run build`, the before one from a worktree at `main`.

| | dist total |
|---|---:|
| `main` | 2,618,358 |
| this branch | 1,440,338 |

The bundle drops 1,178,020 bytes, 1.12 MiB, 45% of it.

## What changes here

`newKMSClient` becomes `newCredentials`, and the region is worked out once and passed to both the KMS call and the STS one, so a job still names it at most once. `regionFromKeyId` still covers a key ARN, so `aws_region` is only needed for an alias name or a bare key id.

The inputs and the behaviour of this action are otherwise unchanged.

## One behavioural change worth knowing

Leaving `aws_role_to_assume` unset now falls back to `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` rather than the full AWS credential chain.

That is what `aws-actions/configure-aws-credentials` exports, so the documented way of using this action is unaffected. What is no longer picked up implicitly is IMDS on a self-hosted EC2 runner, `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` on a self-hosted ECS or EKS runner, and a `~/.aws/credentials` profile, which `configure-aws-credentials` writes when `aws-profile` is set. On a hosted runner none of these applies.

The `aws_role_to_assume` and `aws_region` descriptions in `action.yaml` still say "the AWS SDK" and "the standard AWS credential chain". csm-actions/securefix-action#795 corrected the equivalent wording there; worth doing here too, either in this pull request or a follow-up.

## Note on the lockfile

`npm install` couldn't resolve either package: `npm.jsr.io` serves an abbreviated packument with no `versions`, so npm reports `ENOVERSIONS` for any version not already pinned in the lockfile. The entries were written with the `resolved` and `integrity` values from `npm view --registry https://npm.jsr.io`, and `npm install` then completes and verifies them. Worth knowing before the next JSR bump — Renovate may hit the same wall.

csm-actions/securefix-action#795 made the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
