### PR TITLE
docs: describe the credential sources that are actually read

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,19 @@ Token signing is delegated to it.
 
 Set `aws_kms_key_id` instead of `app_private_key`. Passing it as a key ARN is
 enough, since an ARN carries its region; for an alias or a bare key id, set
-`aws_region` or leave it to the AWS SDK.
+`aws_region`, or set `AWS_REGION`.
 
 Set `aws_role_to_assume` and this action assumes the IAM role itself with the
 GitHub OIDC token. The AWS credentials then stay inside the action and are never
-exported, so later steps of the job can't see them. Leaving it unset uses the
-standard AWS credential chain, so `aws-actions/configure-aws-credentials` works
-as well.
+exported, so later steps of the job can't see them.
+
+Leaving `aws_role_to_assume` unset reads the credentials from
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN`, which is
+what `aws-actions/configure-aws-credentials` exports, so running that action
+first works as well. Those environment variables are the only other source: a
+profile in `~/.aws/credentials`, IMDS on a self-hosted EC2 runner and the
+credentials of an ECS or EKS task are not read, so reach for
+`aws-actions/configure-aws-credentials` to use any of them.
 
 ```yaml
 permissions:

--- a/action.yaml
+++ b/action.yaml
@@ -30,10 +30,11 @@ inputs:
     required: false
   aws_region:
     description: |
-      The AWS region of the KMS key.
+      The AWS region of the KMS key, which is also the region of the STS
+      endpoint when aws_role_to_assume is set.
       It can be omitted when aws_kms_key_id is an ARN, which carries the region.
-      Otherwise it falls back to the AWS SDK's own resolution, such as the
-      AWS_REGION environment variable.
+      Otherwise it falls back to AWS_REGION or AWS_DEFAULT_REGION, and the
+      action fails when none of them says which region the key is in.
     required: false
   aws_role_to_assume:
     description: |
@@ -41,8 +42,13 @@ inputs:
       The job needs the permission `id-token: write`.
       The credentials are kept inside this action and are never exported, so
       later steps of the job can't see them.
-      Leave this unset to use the standard AWS credential chain instead, which
-      is what aws-actions/configure-aws-credentials sets up.
+      Leave this unset to read credentials from AWS_ACCESS_KEY_ID,
+      AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN instead, which is what
+      aws-actions/configure-aws-credentials exports.
+      Those environment variables are the only other source. A profile in
+      ~/.aws/credentials, IMDS on a self-hosted EC2 runner and the credentials
+      of an ECS or EKS task aren't read, so run
+      aws-actions/configure-aws-credentials first to use any of them.
     required: false
 
   # For Client


### PR DESCRIPTION
This action no longer goes through the AWS SDK, so `the standard AWS credential chain` and `the AWS SDK's own resolution` no longer describe what happens.

Credentials come from `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` when `aws_role_to_assume` is unset, and nothing else is read. This says so, and names what that leaves out: a `~/.aws/credentials` profile, IMDS on a self-hosted EC2 runner, and the credentials of an ECS or EKS task. Running `aws-actions/configure-aws-credentials` first covers all of them, since it exports those environment variables.

The region falls back to `AWS_REGION` or `AWS_DEFAULT_REGION` and the action fails when neither says anything, rather than being resolved by the SDK from `~/.aws/config` as well.

Documentation only — no behaviour changes. The behaviour itself changed in the pull request that dropped the SDK; this is the wording that was left behind, which csm-actions/securefix-action#795 corrected on its side at the time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
